### PR TITLE
layout: fix edit on github and event urls

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -48,7 +48,7 @@
     </div>
     <footer>
       Something to add?
-      <a href="{{site.github.repository_url}}/blob/gh-pages/{{page.path}}" class="btn btn-github">
+      <a href="{{site.github.repository_url}}/blob/master/{{page.path}}" class="btn btn-github">
         <span class="icon"></span>
          Edit on GitHub
       </a>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -36,10 +36,10 @@
             @ {{page.location | markdownify | remove: '<p>' | remove: '</p>'  }}
           {% endif %}
           {% if page.meetupUrl %}
-            // <a href='{{ page.meetupUrl }}/'>[&nbsp;Meetup&nbsp;]</a>
+            // <a href='{{ page.meetupUrl }}'>[&nbsp;Meetup&nbsp;]</a>
           {% endif %}
           {% if page.photosUrl %}
-            // <a href='{{ page.photosUrl }}/'>[&nbsp;Photos&nbsp;]</a>
+            // <a href='{{ page.photosUrl }}'>[&nbsp;Photos&nbsp;]</a>
           {% endif %}
         </h3>
 


### PR DESCRIPTION
meetup.com event links break if there are more than one trailing slash. this doesn't affect the photos URL for some reason.

For example:
- https://www.meetup.com/Berlin-Hack-and-Tell/events/252068900  (works)
- https://www.meetup.com/Berlin-Hack-and-Tell/events/252068900/ (works)
- https://www.meetup.com/Berlin-Hack-and-Tell/events/252068900// (fails)
- https://www.meetup.com/Berlin-Hack-and-Tell/events/252068900// (fails)
