### PR TITLE
Shorten description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 name: Berlin Hack & Tell
 description: >
   Berlin Hack and Tell is a monthly meetup where eight people present their hacks. You have five minutes followed by up to five minutes of questions. Show us code, not slides or a sales pitch!
-  Follow our [Code of Conduct](https://hackandtell.org/#code_of_conduct) and show off a silly/hobby project that you cannot present elsewhere. Think of it like "stand up hacking".
+  Follow our [Code of Conduct](https://hackandtell.org/#code_of_conduct) and show off a silly/hobby project that you can't present elsewhere. Think of it like "stand up hacking".
   Check out the past projects below and sign up on our Meetup page!
 url: http://berlinhackandtell.rocks
 logo: /assets/logo.jpg

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 name: Berlin Hack & Tell
 description: >
-  Berlin Hack and Tell is a monthly meetup where eight people present their hacks. You have five minutes followed by up to five minutes of questions. Show us code, not a slide deck or sales pitch!
-  Follow our [Code of Conduct](https://hackandtell.org/#code_of_conduct) and show off a silly/hobby project from your GitHub that you cannot present elsewhere. Think of it like "stand up hacking".
+  Berlin Hack and Tell is a monthly meetup where eight people present their hacks. You have five minutes followed by up to five minutes of questions. Show us code, not slides or a sales pitch!
+  Follow our [Code of Conduct](https://hackandtell.org/#code_of_conduct) and show off a silly/hobby project that you cannot present elsewhere. Think of it like "stand up hacking".
   Check out the past projects below and sign up on our Meetup page!
 url: http://berlinhackandtell.rocks
 logo: /assets/logo.jpg


### PR DESCRIPTION
Shorten the description even more.

Along the way, removing the reference to GitHub for 2 reasons:

1) There are also BitBucket, GitLab, Savannah, etc.
2) The real pearls are often in some very old folders on someone's hard disk, and BHNT might encourage them to cleanup and publish them in the first place.