### PR TITLE
No smoking

### DIFF
--- a/_slides/2019-09-24-no74-post-cccamp19-hacks.md
+++ b/_slides/2019-09-24-no74-post-cccamp19-hacks.md
@@ -32,6 +32,7 @@ We start 19:15 *sharpIsh*
 ## Rules
 
 1. Be excellent to each other
+1. Do not smoke
 1. You get 5 minutes to present in English
 1. You or your team should have built it yourself
 1. People get 5 minutes Q&A afterwards


### PR DESCRIPTION
In future events, we should mention the no-smoking rule right at the beginning. The sign at the c-base bar is too easily overlooked.

One might argue that this is more a rule of the venue than a rule of the event, but that wouldn't be accurate: c-base is smoking-permitted by default, and BHNT is one of the events who opted to be non-smoking.

During initial presentation, one might mention that smoking is permitted outside, but I didn't want to clutter the rules page with that level of detail.