### PR TITLE
Add BHNT 77

### DIFF
--- a/_posts/2020-01-28-hacking-2020.md
+++ b/_posts/2020-01-28-hacking-2020.md
@@ -1,0 +1,18 @@
+---
+layout: post
+title: Berlin Hack & Tell \#77 - Hacking 2020
+date: 2020-01-28
+time: '19:15'
+location: '[c-base](https://www.c-base.org)'
+meetupUrl: https://www.meetup.com/de-DE/Berlin-Hack-and-Tell/events/268089955/
+---
+
+* [Vote2p](https://github.com/gimlet2/vote2p) (voting, ipfs, pubsub) by [[Andrey](https://github.com/gimlet2)
+* [FPGA Badge Hack](https://hackaday.io/page/6764-hackaday-supercon-badge-boots-linux-using-sdram-cartridge) - Linux on RISC-V by [Drew Fustini](https://github.com/pdp7)
+* [obfuscated compressor](https://ioccc.org/2019/diels-grabsch1/hint.html) by Volker [Diels-Grabsch](https://njh.eu)
+* [supericon](https://github.com/momonala/supersizeme) by [Mohit Nalavadi](https://github.com/momonala)
+
+* doorbell monitor by [Jaseg](https://github.com/jaseg)
+* [sonic creatures: melodic harp circuit sculpture](https://www.youtube.com/watch?v=_8q6Gq_PAiE) by [Helen Leigh](https://www.youtube.com/user/helenlsteer) - **Hack of the month**
+* gpx-stats (GPS statistics bash script) by Victor
+* [hallelujah.io](https://hallelujah.io) by [Philipp](https://github.com/strathausen)

--- a/_posts/2020-01-28-hacking-2020.md
+++ b/_posts/2020-01-28-hacking-2020.md
@@ -10,7 +10,7 @@ meetupUrl: https://www.meetup.com/de-DE/Berlin-Hack-and-Tell/events/268089955/
 * [Vote2p](https://github.com/gimlet2/vote2p) (voting, ipfs, pubsub) by [[Andrey](https://github.com/gimlet2)
 * [FPGA Badge Hack](https://hackaday.io/page/6764-hackaday-supercon-badge-boots-linux-using-sdram-cartridge) - Linux on RISC-V by [Drew Fustini](https://github.com/pdp7)
 * [obfuscated compressor](https://ioccc.org/2019/diels-grabsch1/hint.html) by Volker [Diels-Grabsch](https://njh.eu)
-* [supericon](https://github.com/momonala/supersizeme) by [Mohit Nalavadi](https://github.com/momonala)
+* [Super Resolution HTTP API](https://github.com/momonala/supersizeme) by [Mohit Nalavadi](https://github.com/momonala)
 
 * doorbell monitor by [Jaseg](https://github.com/jaseg)
 * [sonic creatures: melodic harp circuit sculpture](https://www.youtube.com/watch?v=_8q6Gq_PAiE) by [Helen Leigh](https://www.youtube.com/user/helenlsteer) - **Hack of the month**


### PR DESCRIPTION
most info condensed and formatted to our standard format from https://pad.systemli.org/p/bhnt077

cc @gimlet2 @pdp7  @vog @momonala @jaseg @strathausen - thanks for presenting and maybe you can check/add details/links for your projects

we should also think about conserving the rest of the data in the pad - the tags and the flea market stuff is interesting. Not yet sure exactly where to add it - but it should be part of the website IMHO as the pad might/will disappear.
Thanks @Wikinaut & @lucasrangit for the pad - seems like a really good supporting infrastructure for BHNT