### PR TITLE
dependabot: ignore the old version scheme when @dependabot is checking for updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "urlchecker-action"
+        # Ignore old version scheme
+        versions: ["0.2.x"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,4 @@ updates:
     ignore:
       - dependency-name: "urlchecker-action"
         # Ignore old version scheme
-        versions: ["0.2.x"]
+        versions: ["0.2.x", "0.1.x"]


### PR DESCRIPTION
The version scheme switch from 0.2.31 to 0.0.25  and it's confusing the @dependabot.

Maybe this is a workaround to the auto-updates treating the old version scheme as newer.