### PR TITLE
Add PR template with URL check reminder

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,1 @@
+_Please check links by adding the [needs-url-checks](https://github.com/berlin-hack-and-tell/berlinhackandtell.rocks/labels/needs-url-checks) label to your PR_

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,1 @@
-_Please check links by adding the [needs-url-checks](https://github.com/berlin-hack-and-tell/berlinhackandtell.rocks/labels/needs-url-checks) label to your PR_
+_Please check links by adding the [needs-url-checks](https://github.com/berlin-hack-and-tell/berlinhackandtell.rocks/labels/needs-url-checks) label to your PR._


### PR DESCRIPTION
The GitHub Action I added uses a label to trigger, which is very hard to discover. I think we should add a reminder to the PR template. Will look like the following. If you think we should make this a mandatory check for PR then I can configure that instead of relying on memory.

_Please check links by adding the [needs-url-checks](https://github.com/berlin-hack-and-tell/berlinhackandtell.rocks/labels/needs-url-checks) label to your PR._