### PR TITLE
Add script to copy announcement into posting

### DIFF
--- a/copy-announcement.sh
+++ b/copy-announcement.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -eu
+
+echo 'Fetching list of events ...'
+event_list_json=$(curl -#f "https://api.meetup.com/berlin-hack-and-tell/")
+event_id=$(echo "${event_list_json}" | sed -n 's/^.*"next_event":{[^}]*"id":"\([^"]*\)".*$/\1/p')
+echo 'Fetching upcoming event ...'
+event_json=$(curl -#f "https://api.meetup.com/berlin-hack-and-tell/events/${event_id}/")
+local_date=$(echo "${event_json}" | sed -n 's/^.*"local_date":"\([^"]*\)".*$/\1/p')
+local_time=$(echo "${event_json}" | sed -n 's/^.*"local_time":"\([^"]*\)".*$/\1/p')
+name=$(echo "${event_json}" | sed -n 's/{[^{]*"name":"\([^"]*\)".*$/\1/p')
+bhnt_no=$(echo "${name}" | sed -n 's/^[^#]*#\([0-9]\+\).*$/\1/p')
+bhnt_title=$(echo "${name}" | sed -n 's/^\(.*[^ ]\) * - BHNT .*$/\1/p')
+file_title=$(echo "${bhnt_title}" | tr A-Z a-z | sed 's/[^0-9a-z]/-/g')
+post_file="_posts/${local_date}-no${bhnt_no}-hackgpt.md"
+
+
+echo
+echo "Generating ${post_file} ..."
+echo '#############################################################################'
+
+tee "${post_file}" <<EOF
+---
+layout: post
+title: Berlin Hack & Tell \\#${bhnt_no} - ${bhnt_title}
+date: ${local_date}
+published: true
+time: '${local_time}'
+location: '[c-base](https://www.c-base.org)'
+meetupUrl: https://www.meetup.com/de-DE/berlin-hack-and-tell/events/${event_id}
+---
+
+Upcoming
+EOF
+echo '#############################################################################'
+
+echo
+echo 'Done.'
+echo


### PR DESCRIPTION
This script is meant to be executed immediately after creating the announcement on Meetup.

It creates a posting file in `_posts/` with proper name and proper contents.

In the future, if this script turns out to be reliable, we could also add some git commands to it, to streaming the process even further, e.g.:

```
git add _posts/FILENAME
git commit -m '...SOME PROPER COMMENT...' _posts/FILENAME
git push
```
